### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20
+    target-branch: develop
+    reviewers:
+      - 'hyorimitsu'


### PR DESCRIPTION
This PR adds Dependabot configuration to automate dependency management for the Amazon CloudWatch Logs MCP server project.