### PR TITLE
Add describe_log_groups tool to list and describe CloudWatch Logs log groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ To use the MCP server, you need to configure it with your AWS credentials. You c
 
 ## Available Tools
 
-| Tool Name        | Description                                    |
-| ---------------- | ---------------------------------------------- |
-| create_log_group | Creates a new Amazon CloudWatch Logs log group |
+| Tool Name           | Description                                         |
+| ------------------- | --------------------------------------------------- |
+| create_log_group    | Creates a new Amazon CloudWatch Logs log group      |
+| describe_log_groups | List and describe Amazon CloudWatch Logs log groups |
 
 For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloud-watch-logs/blob/main/TOOLS.md).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -50,7 +50,7 @@ List and describe Amazon CloudWatch Logs log groups.
 
 **Parameters:**
 
-- `accoutIdentifiers` (array of strings, optional): When `includeLinkedAccounts` is set to `True`, use this parameter to specify the list of accounts to search
+- `accountIdentifiers` (array of strings, optional): When `includeLinkedAccounts` is set to `True`, use this parameter to specify the list of accounts to search
 - `logGroupNamePrefix` (string, optional): The prefix to match
 - `logGroupNamePattern` (string, optional): If you specify a string for this parameter, the operation returns only log groups that have names that match the string based on a case-sensitive substring search
 - `nextToken` (string, optional): The token for the next set of items to return

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -19,6 +19,8 @@ Creates a new Amazon CloudWatch Logs log group.
 
 **Example:**
 
+Request:
+
 ```json
 {
   "logGroupName": "my-application-logs",
@@ -29,15 +31,13 @@ Creates a new Amazon CloudWatch Logs log group.
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
   "$metadata": {
     "httpStatusCode": 200,
     "requestId": "example-request-id",
-    "extendedRequestId": "example-extended-request-id",
-    "cfId": "example-cf-id",
     "attempts": 1,
     "totalRetryDelay": 0
   }
@@ -60,6 +60,8 @@ List and describe Amazon CloudWatch Logs log groups.
 
 **Example:**
 
+Request:
+
 ```json
 {
   "logGroupNamePrefix": "my-application",
@@ -67,15 +69,13 @@ List and describe Amazon CloudWatch Logs log groups.
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
   "$metadata": {
     "httpStatusCode": 200,
     "requestId": "example-request-id",
-    "extendedRequestId": "example-extended-request-id",
-    "cfId": "example-cf-id",
     "attempts": 1,
     "totalRetryDelay": 0
   },
@@ -83,14 +83,10 @@ List and describe Amazon CloudWatch Logs log groups.
     {
       "logGroupName": "my-application-logs",
       "creationTime": 1617234567890,
-      "retentionInDays": 30,
       "metricFilterCount": 0,
-      "arn": "arn:aws:logs:us-east-1:123456789012:log-group:my-application-logs",
-      "storedBytes": 1234567,
-      "kmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-abcdef123456",
-      "dataProtectionStatus": "ACTIVATED",
-      "inheritedProperties": ["ACCOUNT_DATA_PROTECTION"],
-      "logGroupClass": "STANDARD"
+      "arn": "arn:aws:logs:us-east-1:123456789012:log-group:my-application-logs:*",
+      "logGroupClass": "STANDARD",
+      "logGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:my-application-logs"
     }
   ],
   "nextToken": "example-next-token"

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -43,3 +43,56 @@ Creates a new Amazon CloudWatch Logs log group.
   }
 }
 ```
+
+### describe_log_groups
+
+List and describe Amazon CloudWatch Logs log groups.
+
+**Parameters:**
+
+- `accoutIdentifiers` (array of strings, optional): When `includeLinkedAccounts` is set to `True`, use this parameter to specify the list of accounts to search
+- `logGroupNamePrefix` (string, optional): The prefix to match
+- `logGroupNamePattern` (string, optional): If you specify a string for this parameter, the operation returns only log groups that have names that match the string based on a case-sensitive substring search
+- `nextToken` (string, optional): The token for the next set of items to return
+- `limit` (number, optional): The maximum number of items returned
+- `includeLinkedAccounts` (boolean, optional): If you are using a monitoring account, set this to `True` to have the operation return log groups in the accounts listed in `accountIdentifiers`
+- `logGroupClass` (string, optional): Specifies the log group class for this log group
+
+**Example:**
+
+```json
+{
+  "logGroupNamePrefix": "my-application",
+  "limit": 10
+}
+```
+
+**Response:**
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "extendedRequestId": "example-extended-request-id",
+    "cfId": "example-cf-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "logGroups": [
+    {
+      "logGroupName": "my-application-logs",
+      "creationTime": 1617234567890,
+      "retentionInDays": 30,
+      "metricFilterCount": 0,
+      "arn": "arn:aws:logs:us-east-1:123456789012:log-group:my-application-logs",
+      "storedBytes": 1234567,
+      "kmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-abcdef123456",
+      "dataProtectionStatus": "ACTIVATED",
+      "inheritedProperties": ["ACCOUNT_DATA_PROTECTION"],
+      "logGroupClass": "STANDARD"
+    }
+  ],
+  "nextToken": "example-next-token"
+}
+```

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.782.0",
     "@modelcontextprotocol/sdk": "^1.8.0",
+    "@smithy/types": "^4.2.0",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.8.0
         version: 1.8.0
+      '@smithy/types':
+        specifier: ^4.2.0
+        version: 4.2.0
       zod:
         specifier: ^3.24.2
         version: 3.24.2

--- a/src/handlers/tools/index.ts
+++ b/src/handlers/tools/index.ts
@@ -47,7 +47,11 @@ export const setRequestHandler = (server: Server) => {
 
       const tool = callTools[request.params.name]
       const args = tool.requestSchema.parse(request.params.arguments)
-      const results = await tool.operationFn(args)
+
+      // Type assertion is needed because TypeScript cannot infer
+      // that the parsed arguments match the expected type for the specific tool
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const results = await tool.operationFn(args as any)
 
       return {
         content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -9,6 +9,10 @@ export const tools: ListToolDefinition = {
     description: 'Create a new Amazon CloudWatch Logs log group',
     inputSchema: zodToJsonSchema(groupsSchema.CreateLogGroupRequestSchema),
   },
+  [ToolName.DescribeLogGroups]: {
+    description: 'List and describe Amazon CloudWatch Logs log groups',
+    inputSchema: zodToJsonSchema(groupsSchema.DescribeLogGroupsRequestSchema),
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for execution)
@@ -16,5 +20,9 @@ export const callTools: CallToolDefinition = {
   [ToolName.CreateLogGroup]: {
     requestSchema: groupsSchema.CreateLogGroupRequestSchema,
     operationFn: groups.createLogGroup,
+  },
+  [ToolName.DescribeLogGroups]: {
+    requestSchema: groupsSchema.DescribeLogGroupsRequestSchema,
+    operationFn: groups.describeLogGroups,
   },
 }

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -8,6 +8,7 @@ import type * as groupsSchema from '../../operations/schemas/groups.ts'
  */
 export const ToolName = {
   CreateLogGroup: 'create_log_group',
+  DescribeLogGroups: 'describe_log_groups',
 } as const
 
 type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
@@ -21,6 +22,11 @@ type ToolConfigurations = {
     requestSchema: typeof groupsSchema.CreateLogGroupRequestSchema
     requestType: z.infer<typeof groupsSchema.CreateLogGroupRequestSchema>
     responseType: z.infer<typeof groupsSchema.CreateLogGroupResponseSchema>
+  }
+  [ToolName.DescribeLogGroups]: {
+    requestSchema: typeof groupsSchema.DescribeLogGroupsRequestSchema
+    requestType: z.infer<typeof groupsSchema.DescribeLogGroupsRequestSchema>
+    responseType: z.infer<typeof groupsSchema.DescribeLogGroupsResponseSchema>
   }
 }
 

--- a/src/operations/groups.ts
+++ b/src/operations/groups.ts
@@ -1,7 +1,12 @@
-import { CreateLogGroupCommand } from '@aws-sdk/client-cloudwatch-logs'
+import { CreateLogGroupCommand, DescribeLogGroupsCommand } from '@aws-sdk/client-cloudwatch-logs'
 import { type z } from 'zod'
 import { client } from '../lib/aws/client.ts'
-import { CreateLogGroupRequestSchema, CreateLogGroupResponseSchema } from './schemas/groups.ts'
+import {
+  CreateLogGroupRequestSchema,
+  CreateLogGroupResponseSchema,
+  DescribeLogGroupsRequestSchema,
+  DescribeLogGroupsResponseSchema,
+} from './schemas/groups.ts'
 
 export const createLogGroup = async (
   params: z.infer<typeof CreateLogGroupRequestSchema>,
@@ -12,4 +17,15 @@ export const createLogGroup = async (
   const output = await client.send(command)
 
   return CreateLogGroupResponseSchema.parse(output)
+}
+
+export const describeLogGroups = async (
+  params: z.infer<typeof DescribeLogGroupsRequestSchema>,
+): Promise<z.infer<typeof DescribeLogGroupsResponseSchema>> => {
+  const input = DescribeLogGroupsRequestSchema.parse(params)
+
+  const command = new DescribeLogGroupsCommand(input)
+  const output = await client.send(command)
+
+  return DescribeLogGroupsResponseSchema.parse(output)
 }

--- a/src/operations/schemas/common.ts
+++ b/src/operations/schemas/common.ts
@@ -1,0 +1,30 @@
+import { type ResponseMetadata } from '@smithy/types'
+import { z } from 'zod'
+import { typeSafeSchema } from '../../lib/zod/helper.ts'
+
+export const MetadataSchema = typeSafeSchema<ResponseMetadata>()(
+  z
+    .object({
+      httpStatusCode: z
+        .number()
+        .describe('The status code of the last HTTP response received for this operation.'),
+      requestId: z
+        .string()
+        .describe(
+          'A unique identifier for the last request sent for this operation. Often requested by AWS service teams to aid in debugging.',
+        ),
+      extendedRequestId: z
+        .string()
+        .describe('A secondary identifier for the last request sent. Used for debugging.'),
+      cfId: z
+        .string()
+        .describe('A tertiary identifier for the last request sent. Used for debugging.'),
+      attempts: z.number().describe('The number of times this operation was attempted.'),
+      totalRetryDelay: z
+        .number()
+        .describe(
+          'The total amount of time (in milliseconds) that was spent waiting between retry attempts.',
+        ),
+    })
+    .describe('Metadata pertaining to this request.'),
+)

--- a/src/operations/schemas/common.ts
+++ b/src/operations/schemas/common.ts
@@ -1,27 +1,33 @@
 import { type ResponseMetadata } from '@smithy/types'
 import { z } from 'zod'
 import { typeSafeSchema } from '../../lib/zod/helper.ts'
+import { type OptionalToUndefined } from '../../types/util.ts'
 
-export const MetadataSchema = typeSafeSchema<ResponseMetadata>()(
+export const MetadataSchema = typeSafeSchema<OptionalToUndefined<ResponseMetadata>>()(
   z
     .object({
       httpStatusCode: z
         .number()
+        .optional()
         .describe('The status code of the last HTTP response received for this operation.'),
       requestId: z
         .string()
+        .optional()
         .describe(
           'A unique identifier for the last request sent for this operation. Often requested by AWS service teams to aid in debugging.',
         ),
       extendedRequestId: z
         .string()
+        .optional()
         .describe('A secondary identifier for the last request sent. Used for debugging.'),
       cfId: z
         .string()
+        .optional()
         .describe('A tertiary identifier for the last request sent. Used for debugging.'),
-      attempts: z.number().describe('The number of times this operation was attempted.'),
+      attempts: z.number().optional().describe('The number of times this operation was attempted.'),
       totalRetryDelay: z
         .number()
+        .optional()
         .describe(
           'The total amount of time (in milliseconds) that was spent waiting between retry attempts.',
         ),

--- a/src/operations/schemas/groups.ts
+++ b/src/operations/schemas/groups.ts
@@ -9,9 +9,12 @@ import {
 } from '@aws-sdk/client-cloudwatch-logs'
 import { z } from 'zod'
 import { typeSafeSchema } from '../../lib/zod/helper.ts'
+import { type OptionalToUndefined } from '../../types/util.ts'
 import { MetadataSchema } from './common.ts'
 
-export const CreateLogGroupRequestSchema = typeSafeSchema<CreateLogGroupCommandInput>()(
+export const CreateLogGroupRequestSchema = typeSafeSchema<
+  OptionalToUndefined<CreateLogGroupCommandInput>
+>()(
   z.object({
     logGroupName: z.string().describe('A name for the log group.'),
     kmsKeyId: z
@@ -29,13 +32,17 @@ export const CreateLogGroupRequestSchema = typeSafeSchema<CreateLogGroupCommandI
   }),
 )
 
-export const CreateLogGroupResponseSchema = typeSafeSchema<CreateLogGroupCommandOutput>()(
+export const CreateLogGroupResponseSchema = typeSafeSchema<
+  OptionalToUndefined<CreateLogGroupCommandOutput>
+>()(
   z.object({
     $metadata: MetadataSchema,
   }),
 )
 
-export const DescribeLogGroupsRequestSchema = typeSafeSchema<DescribeLogGroupsCommandInput>()(
+export const DescribeLogGroupsRequestSchema = typeSafeSchema<
+  OptionalToUndefined<DescribeLogGroupsCommandInput>
+>()(
   z.object({
     accountIdentifiers: z
       .array(z.string())
@@ -65,7 +72,9 @@ export const DescribeLogGroupsRequestSchema = typeSafeSchema<DescribeLogGroupsCo
   }),
 )
 
-export const DescribeLogGroupsResponseSchema = typeSafeSchema<DescribeLogGroupsCommandOutput>()(
+export const DescribeLogGroupsResponseSchema = typeSafeSchema<
+  OptionalToUndefined<DescribeLogGroupsCommandOutput>
+>()(
   z.object({
     $metadata: MetadataSchema,
     logGroups: z

--- a/src/operations/schemas/groups.ts
+++ b/src/operations/schemas/groups.ts
@@ -1,10 +1,15 @@
 import {
   type CreateLogGroupCommandInput,
   type CreateLogGroupCommandOutput,
+  DataProtectionStatus,
+  type DescribeLogGroupsCommandInput,
+  type DescribeLogGroupsCommandOutput,
+  InheritedProperty,
   LogGroupClass,
 } from '@aws-sdk/client-cloudwatch-logs'
 import { z } from 'zod'
 import { typeSafeSchema } from '../../lib/zod/helper.ts'
+import { MetadataSchema } from './common.ts'
 
 export const CreateLogGroupRequestSchema = typeSafeSchema<CreateLogGroupCommandInput>()(
   z.object({
@@ -26,29 +31,90 @@ export const CreateLogGroupRequestSchema = typeSafeSchema<CreateLogGroupCommandI
 
 export const CreateLogGroupResponseSchema = typeSafeSchema<CreateLogGroupCommandOutput>()(
   z.object({
-    $metadata: z
-      .object({
-        httpStatusCode: z
-          .number()
-          .describe('The status code of the last HTTP response received for this operation.'),
-        requestId: z
-          .string()
-          .describe(
-            'A unique identifier for the last request sent for this operation. Often requested by AWS service teams to aid in debugging.',
-          ),
-        extendedRequestId: z
-          .string()
-          .describe('A secondary identifier for the last request sent. Used for debugging.'),
-        cfId: z
-          .string()
-          .describe('A tertiary identifier for the last request sent. Used for debugging.'),
-        attempts: z.number().describe('The number of times this operation was attempted.'),
-        totalRetryDelay: z
-          .number()
-          .describe(
-            'The total amount of time (in milliseconds) that was spent waiting between retry attempts.',
-          ),
-      })
-      .describe('Metadata pertaining to this request.'),
+    $metadata: MetadataSchema,
+  }),
+)
+
+export const DescribeLogGroupsRequestSchema = typeSafeSchema<DescribeLogGroupsCommandInput>()(
+  z.object({
+    accoutIdentifiers: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'When `includeLinkedAccounts` is set to `True`, use this parameter to specify the list of accounts to search.',
+      ),
+    logGroupNamePrefix: z.string().optional().describe('The prefix to match.'),
+    logGroupNamePattern: z
+      .string()
+      .optional()
+      .describe(
+        'If you specify a string for this parameter, the operation returns only log groups that have names that match the string based on a case-sensitive substring search.',
+      ),
+    nextToken: z.string().optional().describe('The token for the next set of items to return.'),
+    limit: z.number().optional().describe('The maximum number of items returned.'),
+    includeLinkedAccounts: z
+      .boolean()
+      .optional()
+      .describe(
+        'If you are using a monitoring account, set this to `True` to have the operation return log groups in the accounts listed in `accountIdentifiers`.',
+      ),
+    logGroupClass: z
+      .nativeEnum(LogGroupClass)
+      .optional()
+      .describe('Specifies the log group class for this log group'),
+  }),
+)
+
+export const DescribeLogGroupsResponseSchema = typeSafeSchema<DescribeLogGroupsCommandOutput>()(
+  z.object({
+    $metadata: MetadataSchema,
+    logGroups: z
+      .array(
+        z.object({
+          logGroupName: z.string().optional().describe('The name of the log group.'),
+          creationTime: z
+            .number()
+            .optional()
+            .describe(
+              'The creation time of the log group, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+            ),
+          retentionInDays: z
+            .number()
+            .optional()
+            .describe('The number of days to retain the log events in the specified log group.'),
+          metricFilterCount: z.number().optional().describe('The number of metric filters.'),
+          arn: z.string().optional().describe('The Amazon Resource Name (ARN) of the log group.'),
+          storedBytes: z.number().optional().describe('The number of bytes stored.'),
+          kmsKeyId: z
+            .string()
+            .optional()
+            .describe(
+              'The Amazon Resource Name (ARN) of the KMS key to use when encrypting log data.',
+            ),
+          dataProtectionStatus: z
+            .nativeEnum(DataProtectionStatus)
+            .optional()
+            .describe(
+              'Displays whether this log group has a protection policy, or whether it had one in the past.',
+            ),
+          inheritedProperties: z
+            .array(z.nativeEnum(InheritedProperty))
+            .optional()
+            .describe(
+              'Displays all the properties that this log group has inherited from account-level settings.',
+            ),
+          logGroupClass: z
+            .nativeEnum(LogGroupClass)
+            .optional()
+            .describe('This specifies the log group class for this log group.'),
+          logGroupArn: z
+            .string()
+            .optional()
+            .describe('The Amazon Resource Name (ARN) of the log group.'),
+        }),
+      )
+      .optional()
+      .describe('The log groups.'),
+    nextToken: z.string().optional().describe('The token for the next set of items to return.'),
   }),
 )

--- a/src/operations/schemas/groups.ts
+++ b/src/operations/schemas/groups.ts
@@ -37,7 +37,7 @@ export const CreateLogGroupResponseSchema = typeSafeSchema<CreateLogGroupCommand
 
 export const DescribeLogGroupsRequestSchema = typeSafeSchema<DescribeLogGroupsCommandInput>()(
   z.object({
-    accoutIdentifiers: z
+    accountIdentifiers: z
       .array(z.string())
       .optional()
       .describe(

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -1,0 +1,80 @@
+/**
+ * Utility type to convert optional properties to explicitly include undefined
+ *
+ * This type recursively transforms properties with optional modifier (?) to explicitly include
+ * undefined in their type union. It works on all levels of nested object structures and arrays,
+ * ensuring type consistency when working with optional properties in TypeScript.
+ *
+ * @template T - The TypeScript type whose optional properties should be transformed
+ *
+ * @example
+ * ```typescript
+ * // Simple object
+ * type User = {
+ *   name?: string;
+ *   age: number;
+ * }
+ *
+ * type UserWithExplicitUndefined = OptionalToUndefined<User>;
+ * // Result:
+ * // {
+ * //   name?: string | undefined;
+ * //   age: number;
+ * // }
+ *
+ * // Nested object
+ * type NestedUser = {
+ *   name?: string;
+ *   profile?: {
+ *     age?: number;
+ *     address: {
+ *       city?: string;
+ *       country: string;
+ *     };
+ *   };
+ * }
+ *
+ * type NestedUserWithExplicitUndefined = OptionalToUndefined<NestedUser>;
+ * // Result:
+ * // {
+ * //   name?: string | undefined;
+ * //   profile?: {
+ * //     age?: number | undefined;
+ * //     address: {
+ * //       city?: string | undefined;
+ * //       country: string;
+ * //     };
+ * //   } | undefined;
+ * // }
+ *
+ * // Arrays
+ * type UserWithArray = {
+ *   name?: string;
+ *   friends?: { id: number; name?: string }[];
+ * }
+ *
+ * type UserWithArrayExplicitUndefined = OptionalToUndefined<UserWithArray>;
+ * // Result:
+ * // {
+ * //   name?: string | undefined;
+ * //   friends?: { id: number; name?: string | undefined }[] | undefined;
+ * // }
+ * ```
+ *
+ * @returns A new type with all optional properties explicitly including undefined at all nesting levels
+ */
+export type OptionalToUndefined<T> = {
+  [K in keyof T]: undefined extends T[K]
+    ? T[K] extends undefined
+      ? T[K]
+      : T[K] extends (infer U)[]
+        ? OptionalToUndefined<U>[] | undefined
+        : T[K] extends object
+          ? OptionalToUndefined<T[K]> | undefined
+          : T[K] | undefined
+    : T[K] extends (infer U)[]
+      ? OptionalToUndefined<U>[]
+      : T[K] extends object
+        ? OptionalToUndefined<T[K]>
+        : T[K]
+}


### PR DESCRIPTION
## Overview

This PR adds a new tool `describe_log_groups` to the Amazon CloudWatch Logs MCP server. This tool allows users to list and describe existing log groups in CloudWatch Logs, complementing the existing `create_log_group` functionality.

## Changes

- Added `DescribeLogGroups` to the `ToolName` enum in `src/handlers/tools/types.ts`
- Created request and response schemas in `src/operations/schemas/groups.ts`:
  - `DescribeLogGroupsRequestSchema` with parameters for filtering and pagination
  - `DescribeLogGroupsResponseSchema` for the returned log groups data
- Implemented the `describeLogGroups` operation function in `src/operations/groups.ts`
- Added the tool to the available tools in `src/handlers/tools/tools.ts`
- Fixed a TypeScript type issue in `src/handlers/tools/index.ts` by adding a type assertion
- Updated documentation:
  - Added the new tool to the "Available Tools" table in README.md
  - Added detailed documentation for the tool in TOOLS.md

## Documentation

Documentation has been updated to reflect the new functionality, including parameter descriptions and example usage.