### PR TITLE
Add delete_log_group tool to support log group deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To use the MCP server, you need to configure it with your AWS credentials. You c
 | ------------------- | --------------------------------------------------- |
 | create_log_group    | Creates a new Amazon CloudWatch Logs log group      |
 | describe_log_groups | List and describe Amazon CloudWatch Logs log groups |
+| delete_log_group    | Delete an Amazon CloudWatch Logs log group          |
 
 For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloud-watch-logs/blob/main/TOOLS.md).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -92,3 +92,34 @@ Response:
   "nextToken": "example-next-token"
 }
 ```
+
+### delete_log_group
+
+Delete an Amazon CloudWatch Logs log group.
+
+**Parameters:**
+
+- `logGroupName` (string, required): The name of the log group
+
+**Example:**
+
+Request:
+
+```json
+{
+  "logGroupName": "my-application-logs"
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  }
+}
+```

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -13,6 +13,10 @@ export const tools: ListToolDefinition = {
     description: 'List and describe Amazon CloudWatch Logs log groups',
     inputSchema: zodToJsonSchema(groupsSchema.DescribeLogGroupsRequestSchema),
   },
+  [ToolName.DeleteLogGroup]: {
+    description: 'Delete an Amazon CloudWatch Logs log group',
+    inputSchema: zodToJsonSchema(groupsSchema.DeleteLogGroupRequestSchema),
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for execution)
@@ -24,5 +28,9 @@ export const callTools: CallToolDefinition = {
   [ToolName.DescribeLogGroups]: {
     requestSchema: groupsSchema.DescribeLogGroupsRequestSchema,
     operationFn: groups.describeLogGroups,
+  },
+  [ToolName.DeleteLogGroup]: {
+    requestSchema: groupsSchema.DeleteLogGroupRequestSchema,
+    operationFn: groups.deleteLogGroup,
   },
 }

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -9,6 +9,7 @@ import type * as groupsSchema from '../../operations/schemas/groups.ts'
 export const ToolName = {
   CreateLogGroup: 'create_log_group',
   DescribeLogGroups: 'describe_log_groups',
+  DeleteLogGroup: 'delete_log_group',
 } as const
 
 type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
@@ -27,6 +28,11 @@ type ToolConfigurations = {
     requestSchema: typeof groupsSchema.DescribeLogGroupsRequestSchema
     requestType: z.infer<typeof groupsSchema.DescribeLogGroupsRequestSchema>
     responseType: z.infer<typeof groupsSchema.DescribeLogGroupsResponseSchema>
+  }
+  [ToolName.DeleteLogGroup]: {
+    requestSchema: typeof groupsSchema.DeleteLogGroupRequestSchema
+    requestType: z.infer<typeof groupsSchema.DeleteLogGroupRequestSchema>
+    responseType: z.infer<typeof groupsSchema.DeleteLogGroupResponseSchema>
   }
 }
 

--- a/src/operations/groups.ts
+++ b/src/operations/groups.ts
@@ -1,9 +1,15 @@
-import { CreateLogGroupCommand, DescribeLogGroupsCommand } from '@aws-sdk/client-cloudwatch-logs'
+import {
+  CreateLogGroupCommand,
+  DeleteLogGroupCommand,
+  DescribeLogGroupsCommand,
+} from '@aws-sdk/client-cloudwatch-logs'
 import { type z } from 'zod'
 import { client } from '../lib/aws/client.ts'
 import {
   CreateLogGroupRequestSchema,
   CreateLogGroupResponseSchema,
+  DeleteLogGroupRequestSchema,
+  DeleteLogGroupResponseSchema,
   DescribeLogGroupsRequestSchema,
   DescribeLogGroupsResponseSchema,
 } from './schemas/groups.ts'
@@ -28,4 +34,15 @@ export const describeLogGroups = async (
   const output = await client.send(command)
 
   return DescribeLogGroupsResponseSchema.parse(output)
+}
+
+export const deleteLogGroup = async (
+  params: z.infer<typeof DeleteLogGroupRequestSchema>,
+): Promise<z.infer<typeof DeleteLogGroupResponseSchema>> => {
+  const input = DeleteLogGroupRequestSchema.parse(params)
+
+  const command = new DeleteLogGroupCommand(input)
+  const output = await client.send(command)
+
+  return DeleteLogGroupResponseSchema.parse(output)
 }

--- a/src/operations/schemas/groups.ts
+++ b/src/operations/schemas/groups.ts
@@ -2,6 +2,8 @@ import {
   type CreateLogGroupCommandInput,
   type CreateLogGroupCommandOutput,
   DataProtectionStatus,
+  type DeleteLogGroupCommandInput,
+  type DeleteLogGroupCommandOutput,
   type DescribeLogGroupsCommandInput,
   type DescribeLogGroupsCommandOutput,
   InheritedProperty,
@@ -125,5 +127,21 @@ export const DescribeLogGroupsResponseSchema = typeSafeSchema<
       .optional()
       .describe('The log groups.'),
     nextToken: z.string().optional().describe('The token for the next set of items to return.'),
+  }),
+)
+
+export const DeleteLogGroupRequestSchema = typeSafeSchema<
+  OptionalToUndefined<DeleteLogGroupCommandInput>
+>()(
+  z.object({
+    logGroupName: z.string().describe('The name of the log group.'),
+  }),
+)
+
+export const DeleteLogGroupResponseSchema = typeSafeSchema<
+  OptionalToUndefined<DeleteLogGroupCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
   }),
 )


### PR DESCRIPTION
### Overview

This PR adds the `delete_log_group` tool to the Amazon CloudWatch Logs MCP Server, enabling users to delete CloudWatch Logs log groups through the MCP interface.

### Changes

- Added DeleteLogGroup schemas in `src/operations/schemas/groups.ts`
- Implemented the `deleteLogGroup` function in `src/operations/groups.ts`
- Added the DeleteLogGroup tool name in `src/handlers/tools/types.ts`
- Registered the new tool in `src/handlers/tools/tools.ts`
- Updated documentation in `TOOLS.md` and `README.md`