### PR TITLE
Add log-stream-related tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ To use the MCP server, you need to configure it with your AWS credentials. You c
 
 ## Available Tools
 
-| Tool Name           | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| create_log_group    | Creates a new Amazon CloudWatch Logs log group                 |
-| describe_log_groups | List and describe Amazon CloudWatch Logs log groups            |
-| delete_log_group    | Delete an Amazon CloudWatch Logs log group                     |
-| create_log_stream   | Create a new log stream in an Amazon CloudWatch Logs log group |
+| Tool Name            | Description                                                          |
+| -------------------- | -------------------------------------------------------------------- |
+| create_log_group     | Creates a new Amazon CloudWatch Logs log group                       |
+| describe_log_groups  | List and describe Amazon CloudWatch Logs log groups                  |
+| delete_log_group     | Delete an Amazon CloudWatch Logs log group                           |
+| create_log_stream    | Create a new log stream in an Amazon CloudWatch Logs log group       |
+| describe_log_streams | List and describe log streams in an Amazon CloudWatch Logs log group |
 
 For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloud-watch-logs/blob/main/TOOLS.md).
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ To use the MCP server, you need to configure it with your AWS credentials. You c
 
 ## Available Tools
 
-| Tool Name           | Description                                         |
-| ------------------- | --------------------------------------------------- |
-| create_log_group    | Creates a new Amazon CloudWatch Logs log group      |
-| describe_log_groups | List and describe Amazon CloudWatch Logs log groups |
-| delete_log_group    | Delete an Amazon CloudWatch Logs log group          |
+| Tool Name           | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| create_log_group    | Creates a new Amazon CloudWatch Logs log group                 |
+| describe_log_groups | List and describe Amazon CloudWatch Logs log groups            |
+| delete_log_group    | Delete an Amazon CloudWatch Logs log group                     |
+| create_log_stream   | Create a new log stream in an Amazon CloudWatch Logs log group |
 
 For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloud-watch-logs/blob/main/TOOLS.md).
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ To use the MCP server, you need to configure it with your AWS credentials. You c
 | delete_log_group     | Delete an Amazon CloudWatch Logs log group                           |
 | create_log_stream    | Create a new log stream in an Amazon CloudWatch Logs log group       |
 | describe_log_streams | List and describe log streams in an Amazon CloudWatch Logs log group |
+| delete_log_stream    | Delete a log stream in an Amazon CloudWatch Logs log group           |
 
 For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloud-watch-logs/blob/main/TOOLS.md).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -156,3 +156,55 @@ Response:
   }
 }
 ```
+
+### describe_log_streams
+
+List and describe log streams in an Amazon CloudWatch Logs log group.
+
+**Parameters:**
+
+- `logGroupName` (string, optional): The name of the log group
+- `logGroupIdentifier` (string, optional): Specify either the name or ARN of the log group to view
+- `logStreamNamePrefix` (string, optional): The prefix to match
+- `orderBy` (string, optional): If the value is `LogStreamName`, the results are ordered by log stream name
+- `descending` (boolean, optional): If the value is true, results are returned in descending order
+- `nextToken` (string, optional): The token for the next set of items to return
+- `limit` (number, optional): The maximum number of items returned
+
+**Example:**
+
+Request:
+
+```json
+{
+  "logGroupName": "my-application-logs",
+  "logStreamNamePrefix": "instance-",
+  "limit": 10
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "logStreams": [
+    {
+      "logStreamName": "instance-1234",
+      "creationTime": 1617234567890,
+      "firstEventTimestamp": 1617234568000,
+      "lastEventTimestamp": 1617234569000,
+      "lastIngestionTime": 1617234570000,
+      "uploadSequenceToken": "example-sequence-token",
+      "arn": "arn:aws:logs:us-east-1:123456789012:log-group:my-application-logs:log-stream:instance-1234",
+      "storedBytes": 1024
+    }
+  ],
+  "nextToken": "example-next-token"
+}
+```

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -123,3 +123,36 @@ Response:
   }
 }
 ```
+
+### create_log_stream
+
+Create a new log stream in an Amazon CloudWatch Logs log group.
+
+**Parameters:**
+
+- `logGroupName` (string, required): The name of the log group
+- `logStreamName` (string, required): The name of the log stream
+
+**Example:**
+
+Request:
+
+```json
+{
+  "logGroupName": "my-application-logs",
+  "logStreamName": "instance-1234"
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  }
+}
+```

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -208,3 +208,36 @@ Response:
   "nextToken": "example-next-token"
 }
 ```
+
+### delete_log_stream
+
+Delete a log stream in an Amazon CloudWatch Logs log group.
+
+**Parameters:**
+
+- `logGroupName` (string, required): The name of the log group
+- `logStreamName` (string, required): The name of the log stream
+
+**Example:**
+
+Request:
+
+```json
+{
+  "logGroupName": "my-application-logs",
+  "logStreamName": "instance-1234"
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  }
+}
+```

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -1,6 +1,8 @@
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import * as groups from '../../operations/groups.ts'
 import * as groupsSchema from '../../operations/schemas/groups.ts'
+import * as streamsSchema from '../../operations/schemas/streams.ts'
+import * as streams from '../../operations/streams.ts'
 import { type CallToolDefinition, type ListToolDefinition, ToolName } from './types.ts'
 
 // Available tools for Amazon CloudWatch Logs operations (for listing)
@@ -17,6 +19,10 @@ export const tools: ListToolDefinition = {
     description: 'Delete an Amazon CloudWatch Logs log group',
     inputSchema: zodToJsonSchema(groupsSchema.DeleteLogGroupRequestSchema),
   },
+  [ToolName.CreateLogStream]: {
+    description: 'Create a new log stream in an Amazon CloudWatch Logs log group',
+    inputSchema: zodToJsonSchema(streamsSchema.CreateLogStreamRequestSchema),
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for execution)
@@ -32,5 +38,9 @@ export const callTools: CallToolDefinition = {
   [ToolName.DeleteLogGroup]: {
     requestSchema: groupsSchema.DeleteLogGroupRequestSchema,
     operationFn: groups.deleteLogGroup,
+  },
+  [ToolName.CreateLogStream]: {
+    requestSchema: streamsSchema.CreateLogStreamRequestSchema,
+    operationFn: streams.createLogStream,
   },
 }

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -23,6 +23,10 @@ export const tools: ListToolDefinition = {
     description: 'Create a new log stream in an Amazon CloudWatch Logs log group',
     inputSchema: zodToJsonSchema(streamsSchema.CreateLogStreamRequestSchema),
   },
+  [ToolName.DescribeLogStreams]: {
+    description: 'List and describe log streams in an Amazon CloudWatch Logs log group',
+    inputSchema: zodToJsonSchema(streamsSchema.DescribeLogStreamsRequestSchema),
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for execution)
@@ -42,5 +46,9 @@ export const callTools: CallToolDefinition = {
   [ToolName.CreateLogStream]: {
     requestSchema: streamsSchema.CreateLogStreamRequestSchema,
     operationFn: streams.createLogStream,
+  },
+  [ToolName.DescribeLogStreams]: {
+    requestSchema: streamsSchema.DescribeLogStreamsRequestSchema,
+    operationFn: streams.describeLogStreams,
   },
 }

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -27,6 +27,10 @@ export const tools: ListToolDefinition = {
     description: 'List and describe log streams in an Amazon CloudWatch Logs log group',
     inputSchema: zodToJsonSchema(streamsSchema.DescribeLogStreamsRequestSchema),
   },
+  [ToolName.DeleteLogStream]: {
+    description: 'Delete a log stream in an Amazon CloudWatch Logs log group',
+    inputSchema: zodToJsonSchema(streamsSchema.DeleteLogStreamRequestSchema),
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for execution)
@@ -50,5 +54,9 @@ export const callTools: CallToolDefinition = {
   [ToolName.DescribeLogStreams]: {
     requestSchema: streamsSchema.DescribeLogStreamsRequestSchema,
     operationFn: streams.describeLogStreams,
+  },
+  [ToolName.DeleteLogStream]: {
+    requestSchema: streamsSchema.DeleteLogStreamRequestSchema,
+    operationFn: streams.deleteLogStream,
   },
 }

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -13,6 +13,7 @@ export const ToolName = {
   DeleteLogGroup: 'delete_log_group',
   CreateLogStream: 'create_log_stream',
   DescribeLogStreams: 'describe_log_streams',
+  DeleteLogStream: 'delete_log_stream',
 } as const
 
 type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
@@ -46,6 +47,11 @@ type ToolConfigurations = {
     requestSchema: typeof streamsSchema.DescribeLogStreamsRequestSchema
     requestType: z.infer<typeof streamsSchema.DescribeLogStreamsRequestSchema>
     responseType: z.infer<typeof streamsSchema.DescribeLogStreamsResponseSchema>
+  }
+  [ToolName.DeleteLogStream]: {
+    requestSchema: typeof streamsSchema.DeleteLogStreamRequestSchema
+    requestType: z.infer<typeof streamsSchema.DeleteLogStreamRequestSchema>
+    responseType: z.infer<typeof streamsSchema.DeleteLogStreamResponseSchema>
   }
 }
 

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -1,5 +1,6 @@
 import { type z } from 'zod'
 import type * as groupsSchema from '../../operations/schemas/groups.ts'
+import type * as streamsSchema from '../../operations/schemas/streams.ts'
 
 /**
  * Object containing all available tool names supported by this MCP server
@@ -10,6 +11,7 @@ export const ToolName = {
   CreateLogGroup: 'create_log_group',
   DescribeLogGroups: 'describe_log_groups',
   DeleteLogGroup: 'delete_log_group',
+  CreateLogStream: 'create_log_stream',
 } as const
 
 type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
@@ -33,6 +35,11 @@ type ToolConfigurations = {
     requestSchema: typeof groupsSchema.DeleteLogGroupRequestSchema
     requestType: z.infer<typeof groupsSchema.DeleteLogGroupRequestSchema>
     responseType: z.infer<typeof groupsSchema.DeleteLogGroupResponseSchema>
+  }
+  [ToolName.CreateLogStream]: {
+    requestSchema: typeof streamsSchema.CreateLogStreamRequestSchema
+    requestType: z.infer<typeof streamsSchema.CreateLogStreamRequestSchema>
+    responseType: z.infer<typeof streamsSchema.CreateLogStreamResponseSchema>
   }
 }
 

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -12,6 +12,7 @@ export const ToolName = {
   DescribeLogGroups: 'describe_log_groups',
   DeleteLogGroup: 'delete_log_group',
   CreateLogStream: 'create_log_stream',
+  DescribeLogStreams: 'describe_log_streams',
 } as const
 
 type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
@@ -40,6 +41,11 @@ type ToolConfigurations = {
     requestSchema: typeof streamsSchema.CreateLogStreamRequestSchema
     requestType: z.infer<typeof streamsSchema.CreateLogStreamRequestSchema>
     responseType: z.infer<typeof streamsSchema.CreateLogStreamResponseSchema>
+  }
+  [ToolName.DescribeLogStreams]: {
+    requestSchema: typeof streamsSchema.DescribeLogStreamsRequestSchema
+    requestType: z.infer<typeof streamsSchema.DescribeLogStreamsRequestSchema>
+    responseType: z.infer<typeof streamsSchema.DescribeLogStreamsResponseSchema>
   }
 }
 

--- a/src/operations/schemas/streams.ts
+++ b/src/operations/schemas/streams.ts
@@ -1,0 +1,25 @@
+import {
+  type CreateLogStreamCommandInput,
+  type CreateLogStreamCommandOutput,
+} from '@aws-sdk/client-cloudwatch-logs'
+import { z } from 'zod'
+import { typeSafeSchema } from '../../lib/zod/helper.ts'
+import { type OptionalToUndefined } from '../../types/util.ts'
+import { MetadataSchema } from './common.ts'
+
+export const CreateLogStreamRequestSchema = typeSafeSchema<
+  OptionalToUndefined<CreateLogStreamCommandInput>
+>()(
+  z.object({
+    logGroupName: z.string().describe('The name of the log group.'),
+    logStreamName: z.string().describe('The name of the log stream.'),
+  }),
+)
+
+export const CreateLogStreamResponseSchema = typeSafeSchema<
+  OptionalToUndefined<CreateLogStreamCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
+  }),
+)

--- a/src/operations/schemas/streams.ts
+++ b/src/operations/schemas/streams.ts
@@ -1,6 +1,9 @@
 import {
   type CreateLogStreamCommandInput,
   type CreateLogStreamCommandOutput,
+  type DescribeLogStreamsCommandInput,
+  type DescribeLogStreamsCommandOutput,
+  OrderBy,
 } from '@aws-sdk/client-cloudwatch-logs'
 import { z } from 'zod'
 import { typeSafeSchema } from '../../lib/zod/helper.ts'
@@ -21,5 +24,72 @@ export const CreateLogStreamResponseSchema = typeSafeSchema<
 >()(
   z.object({
     $metadata: MetadataSchema,
+  }),
+)
+
+export const DescribeLogStreamsRequestSchema = typeSafeSchema<
+  OptionalToUndefined<DescribeLogStreamsCommandInput>
+>()(
+  z.object({
+    logGroupName: z.string().optional().describe('The name of the log group.'),
+    logGroupIdentifier: z
+      .string()
+      .optional()
+      .describe('Specify either the name or ARN of the log group to view.'),
+    logStreamNamePrefix: z.string().optional().describe('The prefix to match.'),
+    orderBy: z
+      .nativeEnum(OrderBy)
+      .optional()
+      .describe('If the value is `LogStreamName`, the results are ordered by log stream name.'),
+    descending: z
+      .boolean()
+      .optional()
+      .describe('If the value is true, results are returned in descending order.'),
+    nextToken: z.string().optional().describe('The token for the next set of items to return.'),
+    limit: z.number().optional().describe('The maximum number of items returned.'),
+  }),
+)
+
+export const DescribeLogStreamsResponseSchema = typeSafeSchema<
+  OptionalToUndefined<DescribeLogStreamsCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
+    logStreams: z
+      .array(
+        z.object({
+          logStreamName: z.string().optional().describe('The name of the log stream.'),
+          creationTime: z
+            .number()
+            .optional()
+            .describe(
+              'The creation time of the stream, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+            ),
+          firstEventTimestamp: z
+            .number()
+            .optional()
+            .describe(
+              'The time of the first event, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+            ),
+          lastEventTimestamp: z
+            .number()
+            .optional()
+            .describe(
+              'The time of the most recent log event in the log stream in CloudWatch Logs.',
+            ),
+          lastIngestionTime: z
+            .number()
+            .optional()
+            .describe(
+              'The ingestion time, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+            ),
+          uploadSequenceToken: z.string().optional().describe('The sequence token.'),
+          arn: z.string().optional().describe('The Amazon Resource Name (ARN) of the log stream.'),
+          storedBytes: z.number().optional().describe('The number of bytes stored.'),
+        }),
+      )
+      .optional()
+      .describe('The log streams.'),
+    nextToken: z.string().optional().describe('The token for the next set of items to return.'),
   }),
 )

--- a/src/operations/schemas/streams.ts
+++ b/src/operations/schemas/streams.ts
@@ -1,6 +1,8 @@
 import {
   type CreateLogStreamCommandInput,
   type CreateLogStreamCommandOutput,
+  type DeleteLogStreamCommandInput,
+  type DeleteLogStreamCommandOutput,
   type DescribeLogStreamsCommandInput,
   type DescribeLogStreamsCommandOutput,
   OrderBy,
@@ -91,5 +93,22 @@ export const DescribeLogStreamsResponseSchema = typeSafeSchema<
       .optional()
       .describe('The log streams.'),
     nextToken: z.string().optional().describe('The token for the next set of items to return.'),
+  }),
+)
+
+export const DeleteLogStreamRequestSchema = typeSafeSchema<
+  OptionalToUndefined<DeleteLogStreamCommandInput>
+>()(
+  z.object({
+    logGroupName: z.string().describe('The name of the log group.'),
+    logStreamName: z.string().describe('The name of the log stream.'),
+  }),
+)
+
+export const DeleteLogStreamResponseSchema = typeSafeSchema<
+  OptionalToUndefined<DeleteLogStreamCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
   }),
 )

--- a/src/operations/streams.ts
+++ b/src/operations/streams.ts
@@ -1,9 +1,15 @@
-import { CreateLogStreamCommand, DescribeLogStreamsCommand } from '@aws-sdk/client-cloudwatch-logs'
+import {
+  CreateLogStreamCommand,
+  DeleteLogStreamCommand,
+  DescribeLogStreamsCommand,
+} from '@aws-sdk/client-cloudwatch-logs'
 import { type z } from 'zod'
 import { client } from '../lib/aws/client.ts'
 import {
   CreateLogStreamRequestSchema,
   CreateLogStreamResponseSchema,
+  DeleteLogStreamRequestSchema,
+  DeleteLogStreamResponseSchema,
   DescribeLogStreamsRequestSchema,
   DescribeLogStreamsResponseSchema,
 } from './schemas/streams.ts'
@@ -28,4 +34,15 @@ export const describeLogStreams = async (
   const output = await client.send(command)
 
   return DescribeLogStreamsResponseSchema.parse(output)
+}
+
+export const deleteLogStream = async (
+  params: z.infer<typeof DeleteLogStreamRequestSchema>,
+): Promise<z.infer<typeof DeleteLogStreamResponseSchema>> => {
+  const input = DeleteLogStreamRequestSchema.parse(params)
+
+  const command = new DeleteLogStreamCommand(input)
+  const output = await client.send(command)
+
+  return DeleteLogStreamResponseSchema.parse(output)
 }

--- a/src/operations/streams.ts
+++ b/src/operations/streams.ts
@@ -1,7 +1,12 @@
-import { CreateLogStreamCommand } from '@aws-sdk/client-cloudwatch-logs'
+import { CreateLogStreamCommand, DescribeLogStreamsCommand } from '@aws-sdk/client-cloudwatch-logs'
 import { type z } from 'zod'
 import { client } from '../lib/aws/client.ts'
-import { CreateLogStreamRequestSchema, CreateLogStreamResponseSchema } from './schemas/streams.ts'
+import {
+  CreateLogStreamRequestSchema,
+  CreateLogStreamResponseSchema,
+  DescribeLogStreamsRequestSchema,
+  DescribeLogStreamsResponseSchema,
+} from './schemas/streams.ts'
 
 export const createLogStream = async (
   params: z.infer<typeof CreateLogStreamRequestSchema>,
@@ -12,4 +17,15 @@ export const createLogStream = async (
   const output = await client.send(command)
 
   return CreateLogStreamResponseSchema.parse(output)
+}
+
+export const describeLogStreams = async (
+  params: z.infer<typeof DescribeLogStreamsRequestSchema>,
+): Promise<z.infer<typeof DescribeLogStreamsResponseSchema>> => {
+  const input = DescribeLogStreamsRequestSchema.parse(params)
+
+  const command = new DescribeLogStreamsCommand(input)
+  const output = await client.send(command)
+
+  return DescribeLogStreamsResponseSchema.parse(output)
 }

--- a/src/operations/streams.ts
+++ b/src/operations/streams.ts
@@ -1,0 +1,15 @@
+import { CreateLogStreamCommand } from '@aws-sdk/client-cloudwatch-logs'
+import { type z } from 'zod'
+import { client } from '../lib/aws/client.ts'
+import { CreateLogStreamRequestSchema, CreateLogStreamResponseSchema } from './schemas/streams.ts'
+
+export const createLogStream = async (
+  params: z.infer<typeof CreateLogStreamRequestSchema>,
+): Promise<z.infer<typeof CreateLogStreamResponseSchema>> => {
+  const input = CreateLogStreamRequestSchema.parse(params)
+
+  const command = new CreateLogStreamCommand(input)
+  const output = await client.send(command)
+
+  return CreateLogStreamResponseSchema.parse(output)
+}


### PR DESCRIPTION
### Overview

This PR adds the log-stream-related tools to the Amazon CloudWatch Logs MCP Server, enabling users to operate CloudWatch Logs log streams through the MCP interface.

### Changes

- Added CreateLogStream / DescribeLogStreams / DeleteLogStream schemas in src/operations/schemas/streams.ts
- Implemented the createLogGroup / describeLogStreams / deleteLogStream function in src/operations/streams.ts
- Added the CreateLogStream / DescribeLogStreams / DeleteLogStream tool name in src/handlers/tools/types.ts
- Registered the new tool in src/handlers/tools/tools.ts
- Updated documentation in TOOLS.md and README.md