### PR TITLE
Add log-events-related tools for CloudWatch Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To use the MCP server, you need to configure it with your AWS credentials. You c
 | create_log_stream    | Create a new log stream in an Amazon CloudWatch Logs log group       |
 | describe_log_streams | List and describe log streams in an Amazon CloudWatch Logs log group |
 | delete_log_stream    | Delete a log stream in an Amazon CloudWatch Logs log group           |
+| put_log_events       | Write log events to a specified log stream in Amazon CloudWatch Logs |
 
 For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloud-watch-logs/blob/main/TOOLS.md).
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ To use the MCP server, you need to configure it with your AWS credentials. You c
 
 ## Available Tools
 
-| Tool Name            | Description                                                          |
-| -------------------- | -------------------------------------------------------------------- |
-| create_log_group     | Creates a new Amazon CloudWatch Logs log group                       |
-| describe_log_groups  | List and describe Amazon CloudWatch Logs log groups                  |
-| delete_log_group     | Delete an Amazon CloudWatch Logs log group                           |
-| create_log_stream    | Create a new log stream in an Amazon CloudWatch Logs log group       |
-| describe_log_streams | List and describe log streams in an Amazon CloudWatch Logs log group |
-| delete_log_stream    | Delete a log stream in an Amazon CloudWatch Logs log group           |
-| put_log_events       | Write log events to a specified log stream in Amazon CloudWatch Logs |
+| Tool Name            | Description                                                               |
+| -------------------- | ------------------------------------------------------------------------- |
+| create_log_group     | Creates a new Amazon CloudWatch Logs log group                            |
+| describe_log_groups  | List and describe Amazon CloudWatch Logs log groups                       |
+| delete_log_group     | Delete an Amazon CloudWatch Logs log group                                |
+| create_log_stream    | Create a new log stream in an Amazon CloudWatch Logs log group            |
+| describe_log_streams | List and describe log streams in an Amazon CloudWatch Logs log group      |
+| delete_log_stream    | Delete a log stream in an Amazon CloudWatch Logs log group                |
+| put_log_events       | Write log events to a specified log stream in Amazon CloudWatch Logs      |
+| get_log_events       | Retrieve log events from a specified log stream in Amazon CloudWatch Logs |
 
 For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloud-watch-logs/blob/main/TOOLS.md).
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,17 @@ To use the MCP server, you need to configure it with your AWS credentials. You c
 
 ## Available Tools
 
-| Tool Name            | Description                                                               |
-| -------------------- | ------------------------------------------------------------------------- |
-| create_log_group     | Creates a new Amazon CloudWatch Logs log group                            |
-| describe_log_groups  | List and describe Amazon CloudWatch Logs log groups                       |
-| delete_log_group     | Delete an Amazon CloudWatch Logs log group                                |
-| create_log_stream    | Create a new log stream in an Amazon CloudWatch Logs log group            |
-| describe_log_streams | List and describe log streams in an Amazon CloudWatch Logs log group      |
-| delete_log_stream    | Delete a log stream in an Amazon CloudWatch Logs log group                |
-| put_log_events       | Write log events to a specified log stream in Amazon CloudWatch Logs      |
-| get_log_events       | Retrieve log events from a specified log stream in Amazon CloudWatch Logs |
+| Tool Name            | Description                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| create_log_group     | Creates a new Amazon CloudWatch Logs log group                                           |
+| describe_log_groups  | List and describe Amazon CloudWatch Logs log groups                                      |
+| delete_log_group     | Delete an Amazon CloudWatch Logs log group                                               |
+| create_log_stream    | Create a new log stream in an Amazon CloudWatch Logs log group                           |
+| describe_log_streams | List and describe log streams in an Amazon CloudWatch Logs log group                     |
+| delete_log_stream    | Delete a log stream in an Amazon CloudWatch Logs log group                               |
+| put_log_events       | Write log events to a specified log stream in Amazon CloudWatch Logs                     |
+| get_log_events       | Retrieve log events from a specified log stream in Amazon CloudWatch Logs                |
+| filter_log_events    | Search log events with a pattern across log groups and streams in Amazon CloudWatch Logs |
 
 For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloud-watch-logs/blob/main/TOOLS.md).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -293,3 +293,61 @@ Response:
   "nextSequenceToken": "49661406557421394122123153072888641584939163463656145986"
 }
 ```
+
+### get_log_events
+
+Retrieve log events from a specified log stream in Amazon CloudWatch Logs.
+
+**Parameters:**
+
+- `logGroupName` (string, optional): The name of the log group
+- `logGroupIdentifier` (string, optional): Specify either the name or ARN of the log group to view events from
+- `logStreamName` (string, required): The name of the log stream
+- `startTime` (number, optional): The start of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC
+- `endTime` (number, optional): The end of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC
+- `nextToken` (string, optional): The token for the next set of items to return
+- `limit` (number, optional): The maximum number of log events returned
+- `startFromHead` (boolean, optional): If the value is true, the earliest log events are returned first. If the value is false, the latest log events are returned first.
+- `unmask` (boolean, optional): Specify true to display the log event fields with all sensitive data unmasked and visible
+
+**Example:**
+
+Request:
+
+```json
+{
+  "logGroupName": "my-application-logs",
+  "logStreamName": "instance-1234",
+  "startTime": 1617234567000,
+  "endTime": 1617234569000,
+  "limit": 100,
+  "startFromHead": true
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "events": [
+    {
+      "timestamp": 1617234567890,
+      "message": "Application started successfully",
+      "ingestionTime": 1617234568000
+    },
+    {
+      "timestamp": 1617234568000,
+      "message": "User login: user123",
+      "ingestionTime": 1617234568500
+    }
+  ],
+  "nextForwardToken": "f/12345678901234567890123456789012345678901234567890123456",
+  "nextBackwardToken": "b/12345678901234567890123456789012345678901234567890123456"
+}
+```

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -351,3 +351,64 @@ Response:
   "nextBackwardToken": "b/12345678901234567890123456789012345678901234567890123456"
 }
 ```
+
+### filter_log_events
+
+Search log events with a pattern across log groups and streams in Amazon CloudWatch Logs.
+
+**Parameters:**
+
+- `logGroupName` (string, optional): The name of the log group to search
+- `logGroupIdentifier` (string, optional): Specify either the name or ARN of the log group to view log events from
+- `logStreamNames` (array of strings, optional): Filters the results to only logs from the log streams in this list
+- `logStreamNamePrefix` (string, optional): Filters the results to include only events from log streams that have names starting with this prefix
+- `startTime` (number, optional): The start of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC
+- `endTime` (number, optional): The end of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC
+- `filterPattern` (string, optional): The filter pattern to use
+- `nextToken` (string, optional): The token for the next set of events to return
+- `limit` (number, optional): The maximum number of events to return
+- `unmask` (boolean, optional): Specify true to display the log event fields with all sensitive data unmasked and visible
+
+**Example:**
+
+Request:
+
+```json
+{
+  "logGroupName": "my-application-logs",
+  "filterPattern": "ERROR",
+  "startTime": 1617234567000,
+  "endTime": 1617234569000,
+  "limit": 100
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "events": [
+    {
+      "logStreamName": "instance-1234",
+      "timestamp": 1617234567890,
+      "message": "ERROR: Database connection failed",
+      "ingestionTime": 1617234568000,
+      "eventId": "12345678901234567890123456789012345678901234567890123456"
+    },
+    {
+      "logStreamName": "instance-5678",
+      "timestamp": 1617234568500,
+      "message": "ERROR: Authentication failed for user 'admin'",
+      "ingestionTime": 1617234569000,
+      "eventId": "98765432109876543210987654321098765432109876543210987654"
+    }
+  ],
+  "nextToken": "eyJsb2dTdHJlYW1OYW1lIjoiaW5zdGFuY2UtNTY3OCIsImV2ZW50SWQiOiI5ODc2NTQzMjEwOTg3NjU0MzIxMDk4NzY1NDMyMTA5ODc2NTQzMjEwOTg3NjU0MzIxMDk4NzY1NCJ9"
+}
+```

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -241,3 +241,55 @@ Response:
   }
 }
 ```
+
+### put_log_events
+
+Write log events to a specified log stream in Amazon CloudWatch Logs.
+
+**Parameters:**
+
+- `logGroupName` (string, required): The name of the log group
+- `logStreamName` (string, required): The name of the log stream
+- `logEvents` (array, required): The log events. Each log event requires:
+  - `timestamp` (number, required): The time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC
+  - `message` (string, required): The raw event message
+- `sequenceToken` (string, optional): The sequence token obtained from the response of the previous `PutLogEvents` call
+- `entity` (object, optional): The entity associated with the log events. This parameter is optional and can be omitted. If provided, there are specific requirements from the AWS CloudWatch Logs service:
+  - `keyAttributes` (object, optional): The attributes of the entity which identify the specific entity, as a list of key-value pairs
+  - `attributes` (object, optional): Additional attributes of the entity that are not used to specify the identity of the entity
+
+**Example:**
+
+Request:
+
+```json
+{
+  "logGroupName": "my-application-logs",
+  "logStreamName": "instance-1234",
+  "logEvents": [
+    {
+      "timestamp": 1617234567890,
+      "message": "Application started successfully"
+    },
+    {
+      "timestamp": 1617234568000,
+      "message": "User login: user123"
+    }
+  ],
+  "sequenceToken": "49039859626139772178092492226314046488092720276871163859"
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "nextSequenceToken": "49661406557421394122123153072888641584939163463656145986"
+}
+```

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -1,5 +1,7 @@
 import { zodToJsonSchema } from 'zod-to-json-schema'
+import * as events from '../../operations/events.ts'
 import * as groups from '../../operations/groups.ts'
+import * as eventsSchema from '../../operations/schemas/events.ts'
 import * as groupsSchema from '../../operations/schemas/groups.ts'
 import * as streamsSchema from '../../operations/schemas/streams.ts'
 import * as streams from '../../operations/streams.ts'
@@ -31,6 +33,10 @@ export const tools: ListToolDefinition = {
     description: 'Delete a log stream in an Amazon CloudWatch Logs log group',
     inputSchema: zodToJsonSchema(streamsSchema.DeleteLogStreamRequestSchema),
   },
+  [ToolName.PutLogEvents]: {
+    description: 'Write log events to a specified log stream in Amazon CloudWatch Logs',
+    inputSchema: zodToJsonSchema(eventsSchema.PutLogEventsRequestSchema),
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for execution)
@@ -58,5 +64,9 @@ export const callTools: CallToolDefinition = {
   [ToolName.DeleteLogStream]: {
     requestSchema: streamsSchema.DeleteLogStreamRequestSchema,
     operationFn: streams.deleteLogStream,
+  },
+  [ToolName.PutLogEvents]: {
+    requestSchema: eventsSchema.PutLogEventsRequestSchema,
+    operationFn: events.putLogEvents,
   },
 }

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -37,6 +37,10 @@ export const tools: ListToolDefinition = {
     description: 'Write log events to a specified log stream in Amazon CloudWatch Logs',
     inputSchema: zodToJsonSchema(eventsSchema.PutLogEventsRequestSchema),
   },
+  [ToolName.GetLogEvents]: {
+    description: 'Retrieve log events from a specified log stream in Amazon CloudWatch Logs',
+    inputSchema: zodToJsonSchema(eventsSchema.GetLogEventsRequestSchema),
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for execution)
@@ -68,5 +72,9 @@ export const callTools: CallToolDefinition = {
   [ToolName.PutLogEvents]: {
     requestSchema: eventsSchema.PutLogEventsRequestSchema,
     operationFn: events.putLogEvents,
+  },
+  [ToolName.GetLogEvents]: {
+    requestSchema: eventsSchema.GetLogEventsRequestSchema,
+    operationFn: events.getLogEvents,
   },
 }

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -41,6 +41,11 @@ export const tools: ListToolDefinition = {
     description: 'Retrieve log events from a specified log stream in Amazon CloudWatch Logs',
     inputSchema: zodToJsonSchema(eventsSchema.GetLogEventsRequestSchema),
   },
+  [ToolName.FilterLogEvents]: {
+    description:
+      'Search log events with a pattern across log groups and streams in Amazon CloudWatch Logs',
+    inputSchema: zodToJsonSchema(eventsSchema.FilterLogEventsRequestSchema),
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for execution)
@@ -76,5 +81,9 @@ export const callTools: CallToolDefinition = {
   [ToolName.GetLogEvents]: {
     requestSchema: eventsSchema.GetLogEventsRequestSchema,
     operationFn: events.getLogEvents,
+  },
+  [ToolName.FilterLogEvents]: {
+    requestSchema: eventsSchema.FilterLogEventsRequestSchema,
+    operationFn: events.filterLogEvents,
   },
 }

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -17,6 +17,7 @@ export const ToolName = {
   DeleteLogStream: 'delete_log_stream',
   PutLogEvents: 'put_log_events',
   GetLogEvents: 'get_log_events',
+  FilterLogEvents: 'filter_log_events',
 } as const
 
 type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
@@ -65,6 +66,11 @@ type ToolConfigurations = {
     requestSchema: typeof eventsSchema.GetLogEventsRequestSchema
     requestType: z.infer<typeof eventsSchema.GetLogEventsRequestSchema>
     responseType: z.infer<typeof eventsSchema.GetLogEventsResponseSchema>
+  }
+  [ToolName.FilterLogEvents]: {
+    requestSchema: typeof eventsSchema.FilterLogEventsRequestSchema
+    requestType: z.infer<typeof eventsSchema.FilterLogEventsRequestSchema>
+    responseType: z.infer<typeof eventsSchema.FilterLogEventsResponseSchema>
   }
 }
 

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -1,4 +1,5 @@
 import { type z } from 'zod'
+import type * as eventsSchema from '../../operations/schemas/events.ts'
 import type * as groupsSchema from '../../operations/schemas/groups.ts'
 import type * as streamsSchema from '../../operations/schemas/streams.ts'
 
@@ -14,6 +15,7 @@ export const ToolName = {
   CreateLogStream: 'create_log_stream',
   DescribeLogStreams: 'describe_log_streams',
   DeleteLogStream: 'delete_log_stream',
+  PutLogEvents: 'put_log_events',
 } as const
 
 type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
@@ -52,6 +54,11 @@ type ToolConfigurations = {
     requestSchema: typeof streamsSchema.DeleteLogStreamRequestSchema
     requestType: z.infer<typeof streamsSchema.DeleteLogStreamRequestSchema>
     responseType: z.infer<typeof streamsSchema.DeleteLogStreamResponseSchema>
+  }
+  [ToolName.PutLogEvents]: {
+    requestSchema: typeof eventsSchema.PutLogEventsRequestSchema
+    requestType: z.infer<typeof eventsSchema.PutLogEventsRequestSchema>
+    responseType: z.infer<typeof eventsSchema.PutLogEventsResponseSchema>
   }
 }
 

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -16,6 +16,7 @@ export const ToolName = {
   DescribeLogStreams: 'describe_log_streams',
   DeleteLogStream: 'delete_log_stream',
   PutLogEvents: 'put_log_events',
+  GetLogEvents: 'get_log_events',
 } as const
 
 type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
@@ -59,6 +60,11 @@ type ToolConfigurations = {
     requestSchema: typeof eventsSchema.PutLogEventsRequestSchema
     requestType: z.infer<typeof eventsSchema.PutLogEventsRequestSchema>
     responseType: z.infer<typeof eventsSchema.PutLogEventsResponseSchema>
+  }
+  [ToolName.GetLogEvents]: {
+    requestSchema: typeof eventsSchema.GetLogEventsRequestSchema
+    requestType: z.infer<typeof eventsSchema.GetLogEventsRequestSchema>
+    responseType: z.infer<typeof eventsSchema.GetLogEventsResponseSchema>
   }
 }
 

--- a/src/operations/events.ts
+++ b/src/operations/events.ts
@@ -1,7 +1,13 @@
-import { GetLogEventsCommand, PutLogEventsCommand } from '@aws-sdk/client-cloudwatch-logs'
+import {
+  FilterLogEventsCommand,
+  GetLogEventsCommand,
+  PutLogEventsCommand,
+} from '@aws-sdk/client-cloudwatch-logs'
 import { type z } from 'zod'
 import { client } from '../lib/aws/client.ts'
 import {
+  FilterLogEventsRequestSchema,
+  FilterLogEventsResponseSchema,
   GetLogEventsRequestSchema,
   GetLogEventsResponseSchema,
   PutLogEventsRequestSchema,
@@ -28,4 +34,15 @@ export const getLogEvents = async (
   const output = await client.send(command)
 
   return GetLogEventsResponseSchema.parse(output)
+}
+
+export const filterLogEvents = async (
+  params: z.infer<typeof FilterLogEventsRequestSchema>,
+): Promise<z.infer<typeof FilterLogEventsResponseSchema>> => {
+  const input = FilterLogEventsRequestSchema.parse(params)
+
+  const command = new FilterLogEventsCommand(input)
+  const output = await client.send(command)
+
+  return FilterLogEventsResponseSchema.parse(output)
 }

--- a/src/operations/events.ts
+++ b/src/operations/events.ts
@@ -1,0 +1,15 @@
+import { PutLogEventsCommand } from '@aws-sdk/client-cloudwatch-logs'
+import { type z } from 'zod'
+import { client } from '../lib/aws/client.ts'
+import { PutLogEventsRequestSchema, PutLogEventsResponseSchema } from './schemas/events.ts'
+
+export const putLogEvents = async (
+  params: z.infer<typeof PutLogEventsRequestSchema>,
+): Promise<z.infer<typeof PutLogEventsResponseSchema>> => {
+  const input = PutLogEventsRequestSchema.parse(params)
+
+  const command = new PutLogEventsCommand(input)
+  const output = await client.send(command)
+
+  return PutLogEventsResponseSchema.parse(output)
+}

--- a/src/operations/events.ts
+++ b/src/operations/events.ts
@@ -1,7 +1,12 @@
-import { PutLogEventsCommand } from '@aws-sdk/client-cloudwatch-logs'
+import { GetLogEventsCommand, PutLogEventsCommand } from '@aws-sdk/client-cloudwatch-logs'
 import { type z } from 'zod'
 import { client } from '../lib/aws/client.ts'
-import { PutLogEventsRequestSchema, PutLogEventsResponseSchema } from './schemas/events.ts'
+import {
+  GetLogEventsRequestSchema,
+  GetLogEventsResponseSchema,
+  PutLogEventsRequestSchema,
+  PutLogEventsResponseSchema,
+} from './schemas/events.ts'
 
 export const putLogEvents = async (
   params: z.infer<typeof PutLogEventsRequestSchema>,
@@ -12,4 +17,15 @@ export const putLogEvents = async (
   const output = await client.send(command)
 
   return PutLogEventsResponseSchema.parse(output)
+}
+
+export const getLogEvents = async (
+  params: z.infer<typeof GetLogEventsRequestSchema>,
+): Promise<z.infer<typeof GetLogEventsResponseSchema>> => {
+  const input = GetLogEventsRequestSchema.parse(params)
+
+  const command = new GetLogEventsCommand(input)
+  const output = await client.send(command)
+
+  return GetLogEventsResponseSchema.parse(output)
 }

--- a/src/operations/schemas/events.ts
+++ b/src/operations/schemas/events.ts
@@ -1,5 +1,7 @@
 import {
   EntityRejectionErrorType,
+  type GetLogEventsCommandInput,
+  type GetLogEventsCommandOutput,
   type PutLogEventsCommandInput,
   type PutLogEventsCommandOutput,
 } from '@aws-sdk/client-cloudwatch-logs'
@@ -82,5 +84,80 @@ export const PutLogEventsResponseSchema = typeSafeSchema<
       })
       .optional()
       .describe('Information about why the entity is rejected when calling `PutLogEvents`.'),
+  }),
+)
+
+export const GetLogEventsRequestSchema = typeSafeSchema<
+  OptionalToUndefined<GetLogEventsCommandInput>
+>()(
+  z.object({
+    logGroupName: z.string().optional().describe('The name of the log group.'),
+    logGroupIdentifier: z
+      .string()
+      .optional()
+      .describe('Specify either the name or ARN of the log group to view events from.'),
+    logStreamName: z.string().describe('The name of the log stream.'),
+    startTime: z
+      .number()
+      .optional()
+      .describe(
+        'The start of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+      ),
+    endTime: z
+      .number()
+      .optional()
+      .describe(
+        'The end of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+      ),
+    nextToken: z.string().optional().describe('The token for the next set of items to return.'),
+    limit: z.number().optional().describe('The maximum number of log events returned.'),
+    startFromHead: z
+      .boolean()
+      .optional()
+      .describe(
+        'If the value is true, the earliest log events are returned first. If the value is false, the latest log events are returned first.',
+      ),
+    unmask: z
+      .boolean()
+      .optional()
+      .describe(
+        'Specify true to display the log event fields with all sensitive data unmasked and visible.',
+      ),
+  }),
+)
+
+export const GetLogEventsResponseSchema = typeSafeSchema<
+  OptionalToUndefined<GetLogEventsCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
+    events: z
+      .array(
+        z.object({
+          timestamp: z
+            .number()
+            .optional()
+            .describe(
+              'The time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+            ),
+          message: z.string().optional().describe('The data contained in the log event.'),
+          ingestionTime: z
+            .number()
+            .optional()
+            .describe(
+              'The time the event was ingested, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+            ),
+        }),
+      )
+      .optional()
+      .describe('The events.'),
+    nextForwardToken: z
+      .string()
+      .optional()
+      .describe('The token for the next set of items in the forward direction.'),
+    nextBackwardToken: z
+      .string()
+      .optional()
+      .describe('The token for the next set of items in the backward direction.'),
   }),
 )

--- a/src/operations/schemas/events.ts
+++ b/src/operations/schemas/events.ts
@@ -1,5 +1,7 @@
 import {
   EntityRejectionErrorType,
+  type FilterLogEventsCommandInput,
+  type FilterLogEventsCommandOutput,
   type GetLogEventsCommandInput,
   type GetLogEventsCommandOutput,
   type PutLogEventsCommandInput,
@@ -159,5 +161,85 @@ export const GetLogEventsResponseSchema = typeSafeSchema<
       .string()
       .optional()
       .describe('The token for the next set of items in the backward direction.'),
+  }),
+)
+
+export const FilterLogEventsRequestSchema = typeSafeSchema<
+  OptionalToUndefined<FilterLogEventsCommandInput>
+>()(
+  z.object({
+    logGroupName: z.string().optional().describe('The name of the log group to search.'),
+    logGroupIdentifier: z
+      .string()
+      .optional()
+      .describe('Specify either the name or ARN of the log group to view log events from.'),
+    logStreamNames: z
+      .array(z.string())
+      .optional()
+      .describe('Filters the results to only logs from the log streams in this list.'),
+    logStreamNamePrefix: z
+      .string()
+      .optional()
+      .describe(
+        'Filters the results to include only events from log streams that have names starting with this prefix.',
+      ),
+    startTime: z
+      .number()
+      .optional()
+      .describe(
+        'The start of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+      ),
+    endTime: z
+      .number()
+      .optional()
+      .describe(
+        'The end of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+      ),
+    filterPattern: z.string().optional().describe('The filter pattern to use.'),
+    nextToken: z.string().optional().describe('The token for the next set of events to return.'),
+    limit: z.number().optional().describe('The maximum number of events to return.'),
+    unmask: z
+      .boolean()
+      .optional()
+      .describe(
+        'Specify true to display the log event fields with all sensitive data unmasked and visible.',
+      ),
+  }),
+)
+
+export const FilterLogEventsResponseSchema = typeSafeSchema<
+  OptionalToUndefined<FilterLogEventsCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
+    events: z
+      .array(
+        z.object({
+          logStreamName: z
+            .string()
+            .optional()
+            .describe('The name of the log stream to which this event belongs.'),
+          timestamp: z
+            .number()
+            .optional()
+            .describe(
+              'The time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+            ),
+          message: z.string().optional().describe('The data contained in the log event.'),
+          ingestionTime: z
+            .number()
+            .optional()
+            .describe(
+              'The time the event was ingested, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+            ),
+          eventId: z.string().optional().describe('The ID of the event.'),
+        }),
+      )
+      .optional()
+      .describe('The matched events.'),
+    nextToken: z
+      .string()
+      .optional()
+      .describe('The token to use when requesting the next set of items.'),
   }),
 )

--- a/src/operations/schemas/events.ts
+++ b/src/operations/schemas/events.ts
@@ -1,0 +1,86 @@
+import {
+  EntityRejectionErrorType,
+  type PutLogEventsCommandInput,
+  type PutLogEventsCommandOutput,
+} from '@aws-sdk/client-cloudwatch-logs'
+import { z } from 'zod'
+import { typeSafeSchema } from '../../lib/zod/helper.ts'
+import { type OptionalToUndefined } from '../../types/util.ts'
+import { MetadataSchema } from './common.ts'
+
+export const PutLogEventsRequestSchema = typeSafeSchema<
+  OptionalToUndefined<PutLogEventsCommandInput>
+>()(
+  z.object({
+    logGroupName: z.string().describe('The name of the log group.'),
+    logStreamName: z.string().describe('The name of the log stream.'),
+    logEvents: z
+      .array(
+        z.object({
+          timestamp: z
+            .number()
+            .describe(
+              'The time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.',
+            ),
+          message: z.string().describe('The raw event message.'),
+        }),
+      )
+      .describe('The log events.'),
+    sequenceToken: z
+      .string()
+      .optional()
+      .describe(
+        'The sequence token obtained from the response of the previous `PutLogEvents` call.',
+      ),
+    entity: z
+      .object({
+        keyAttributes: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe(
+            'The attributes of the entity which identify the specific entity, as a list of key-value pairs.',
+          ),
+        attributes: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe(
+            'Additional attributes of the entity that are not used to specify the identity of the entity.',
+          ),
+      })
+      .optional()
+      .describe('The entity associated with the log events.'),
+  }),
+)
+
+export const PutLogEventsResponseSchema = typeSafeSchema<
+  OptionalToUndefined<PutLogEventsCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
+    nextSequenceToken: z.string().optional().describe('The next sequence token.'),
+    rejectedLogEventsInfo: z
+      .object({
+        tooNewLogEventStartIndex: z
+          .number()
+          .optional()
+          .describe('The index of the first log event that is too new.'),
+        tooOldLogEventEndIndex: z
+          .number()
+          .optional()
+          .describe('The index of the last log event that is too old.'),
+        expiredLogEventEndIndex: z.number().optional().describe('The expired log events.'),
+      })
+      .optional()
+      .describe('The rejected events.'),
+    rejectedEntityInfo: z
+      .object({
+        errorType: z
+          .nativeEnum(EntityRejectionErrorType)
+          .describe(
+            'The type of error that caused the rejection of the entity when calling `PutLogEvents`.',
+          ),
+      })
+      .optional()
+      .describe('Information about why the entity is rejected when calling `PutLogEvents`.'),
+  }),
+)


### PR DESCRIPTION
## Description

This PR adds three new tools to the Amazon CloudWatch Logs MCP server:

1. `put_log_events`: Write log events to a specified log stream in CloudWatch Logs
2. `get_log_events`: Retrieves log events from a specified log stream in CloudWatch Logs
3. `filter_log_events`: Searches log events with a pattern across log groups and streams

## Implementation Details

### put_log_events

- Implemented schema definitions that match AWS SDK types
- Added operation function to write log events to a specified log stream
- Added tool definition and updated documentation

### get_log_events

- Implemented schema definitions that match AWS SDK types
- Added operation function to retrieve log events from a specified log stream
- Added tool definition and updated documentation

### filter_log_events

- Implemented schema definitions that match AWS SDK types
- Added operation function to search log events with patterns
- Added tool definition and updated documentation

## Documentation

- Updated README.md to include the new tools in the Available Tools section
- Added detailed documentation in TOOLS.md with parameters and usage examples
