### PR TITLE
Add read-only mode configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ pnpm run build
 
 ### Configuration
 
+#### AWS Credentials
+
 To use the MCP server, you need to configure it with your AWS credentials. You can do this by setting environment variables:
 
 ```json
@@ -46,21 +48,49 @@ To use the MCP server, you need to configure it with your AWS credentials. You c
 }
 ```
 
+#### Read-Only Mode
+
+You can configure the server to operate in read-only mode by setting the `READONLY` environment variable to `"true"`:
+
+```json
+{
+  "mcpServers": {
+    "amazon-cloudwatch-logs": {
+      "command": "node",
+      "args": ["/path/to/mcp-amazon-cloud-watch-logs/build/index.js"],
+      "env": {
+        "AWS_REGION": "us-east-1",
+        "AWS_ACCESS_KEY_ID": "<YOUR_ACCESS_KEY>",
+        "AWS_SECRET_ACCESS_KEY": "<YOUR_SECRET_KEY>",
+        "READONLY": "true"
+      }
+    }
+  }
+}
+```
+
+When read-only mode is enabled:
+
+- Only READ operations (tools that retrieve or query information) are available
+- WRITE operations (tools that create, modify, or delete resources) are disabled
+
+This is useful for scenarios where you want to allow log viewing but prevent any modifications to your CloudWatch Logs resources. By default, read-only mode is disabled (`READONLY` is set to `"false"`), allowing both read and write operations.
+
 > **Note:** In the future, this project will be published as an npm package and as a Docker image for easier installation and usage.
 
 ## Available Tools
 
-| Tool Name            | Description                                                                              |
-| -------------------- | ---------------------------------------------------------------------------------------- |
-| create_log_group     | Creates a new Amazon CloudWatch Logs log group                                           |
-| describe_log_groups  | List and describe Amazon CloudWatch Logs log groups                                      |
-| delete_log_group     | Delete an Amazon CloudWatch Logs log group                                               |
-| create_log_stream    | Create a new log stream in an Amazon CloudWatch Logs log group                           |
-| describe_log_streams | List and describe log streams in an Amazon CloudWatch Logs log group                     |
-| delete_log_stream    | Delete a log stream in an Amazon CloudWatch Logs log group                               |
-| put_log_events       | Write log events to a specified log stream in Amazon CloudWatch Logs                     |
-| get_log_events       | Retrieve log events from a specified log stream in Amazon CloudWatch Logs                |
-| filter_log_events    | Search log events with a pattern across log groups and streams in Amazon CloudWatch Logs |
+| Tool Name            | Operation Type | Description                                                                              |
+| -------------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| create_log_group     | WRITE          | Creates a new Amazon CloudWatch Logs log group                                           |
+| describe_log_groups  | READ           | List and describe Amazon CloudWatch Logs log groups                                      |
+| delete_log_group     | WRITE          | Delete an Amazon CloudWatch Logs log group                                               |
+| create_log_stream    | WRITE          | Create a new log stream in an Amazon CloudWatch Logs log group                           |
+| describe_log_streams | READ           | List and describe log streams in an Amazon CloudWatch Logs log group                     |
+| delete_log_stream    | WRITE          | Delete a log stream in an Amazon CloudWatch Logs log group                               |
+| put_log_events       | WRITE          | Write log events to a specified log stream in Amazon CloudWatch Logs                     |
+| get_log_events       | READ           | Retrieve log events from a specified log stream in Amazon CloudWatch Logs                |
+| filter_log_events    | READ           | Search log events with a pattern across log groups and streams in Amazon CloudWatch Logs |
 
 For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloud-watch-logs/blob/main/TOOLS.md).
 
@@ -193,6 +223,7 @@ The server is designed to be easily extensible. To add a new CloudWatch Logs ope
          inputSchema: zodToJsonSchema(myOperationSchema.MyOperationRequestSchema),
          requestSchema: myOperationSchema.MyOperationRequestSchema,
          operationFn: myOperation.myOperation,
+         operationType: Operation.READ,
        },
      }
      ```

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -6,7 +6,7 @@ This document provides detailed information about the tools available in the Ama
 
 ## Available Tools
 
-### create_log_group
+### create_log_group [WRITE]
 
 Creates a new Amazon CloudWatch Logs log group.
 
@@ -44,7 +44,7 @@ Response:
 }
 ```
 
-### describe_log_groups
+### describe_log_groups [READ]
 
 List and describe Amazon CloudWatch Logs log groups.
 
@@ -93,7 +93,7 @@ Response:
 }
 ```
 
-### delete_log_group
+### delete_log_group [WRITE]
 
 Delete an Amazon CloudWatch Logs log group.
 
@@ -124,7 +124,7 @@ Response:
 }
 ```
 
-### create_log_stream
+### create_log_stream [WRITE]
 
 Create a new log stream in an Amazon CloudWatch Logs log group.
 
@@ -157,7 +157,7 @@ Response:
 }
 ```
 
-### describe_log_streams
+### describe_log_streams [READ]
 
 List and describe log streams in an Amazon CloudWatch Logs log group.
 
@@ -209,7 +209,7 @@ Response:
 }
 ```
 
-### delete_log_stream
+### delete_log_stream [WRITE]
 
 Delete a log stream in an Amazon CloudWatch Logs log group.
 
@@ -242,7 +242,7 @@ Response:
 }
 ```
 
-### put_log_events
+### put_log_events [WRITE]
 
 Write log events to a specified log stream in Amazon CloudWatch Logs.
 
@@ -294,7 +294,7 @@ Response:
 }
 ```
 
-### get_log_events
+### get_log_events [READ]
 
 Retrieve log events from a specified log stream in Amazon CloudWatch Logs.
 
@@ -352,7 +352,7 @@ Response:
 }
 ```
 
-### filter_log_events
+### filter_log_events [READ]
 
 Search log events with a pattern across log groups and streams in Amazon CloudWatch Logs.
 

--- a/env/types.d.ts
+++ b/env/types.d.ts
@@ -3,5 +3,6 @@ declare namespace NodeJS {
     readonly npm_package_name?: string
     readonly npm_package_version?: string
     readonly AWS_REGION?: string
+    readonly READONLY?: string
   }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,4 +17,9 @@ export const config = {
   aws: {
     region: getEnv(process.env.AWS_REGION, 'us-east-1'),
   },
+  /**
+   * When set to true, only reference operations (read-only) are allowed.
+   * This prevents any operations that would modify AWS resources.
+   */
+  readonly: getEnv(process.env.READONLY, 'false') === 'true',
 }

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -17,9 +17,13 @@ import {
   type ToolNameType,
 } from './types.ts'
 
-type AdditionalProperty = { [N in ToolNameType]: { operationType: OperationType } }
+// prettier-ignore
+type ToolDefinition =
+  ListToolDefinition &
+  CallToolDefinition &
+  { [N in ToolNameType]: { operationType: OperationType } }
 
-export const toolDefinitions: ListToolDefinition & CallToolDefinition & AdditionalProperty = {
+export const toolDefinition: ToolDefinition = {
   [ToolName.CreateLogGroup]: {
     name: ToolName.CreateLogGroup,
     description: 'Create a new Amazon CloudWatch Logs log group',
@@ -96,7 +100,7 @@ export const toolDefinitions: ListToolDefinition & CallToolDefinition & Addition
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for listing)
-export const tools: ListToolDefinitionItem[] = Object.entries(toolDefinitions)
+export const tools: ListToolDefinitionItem[] = Object.entries(toolDefinition)
   .filter(([, value]) => (config.readonly ? value.operationType !== Operation.WRITE : true))
   .map(([, value]) => ({
     name: value.name,
@@ -105,7 +109,7 @@ export const tools: ListToolDefinitionItem[] = Object.entries(toolDefinitions)
   }))
 
 // Available tools for Amazon CloudWatch Logs operations (for execution)
-export const callTools = Object.entries(toolDefinitions)
+export const callTools = Object.entries(toolDefinition)
   .filter(([, value]) => (config.readonly ? value.operationType !== Operation.WRITE : true))
   .reduce<CallToolDefinition>((acc, [key, value]) => {
     if (isToolName(key)) {

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -17,10 +17,22 @@ export const ToolName = {
   FilterLogEvents: 'filter_log_events',
 } as const
 
-type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
+export type ToolNameType = (typeof ToolName)[keyof typeof ToolName]
 
 export const isToolName = (name: unknown): name is ToolNameType =>
   Object.values(ToolName).includes(name as ToolNameType)
+
+/**
+ * Object containing operation types for tools
+ *
+ * Used to indicate whether a tool is for reference (read-only) or for updating (write operations)
+ */
+export const Operation = {
+  READ: 'READ',
+  WRITE: 'WRITE',
+} as const
+
+export type OperationType = (typeof Operation)[keyof typeof Operation]
 
 // Tool definition structure for listing available tools
 export type ListToolDefinitionItem = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { config } from './config/index.ts'
 import { setRequestHandler } from './handlers/tools/index.ts'
-import { toolDefinitions } from './handlers/tools/tools.ts'
+import { toolDefinition } from './handlers/tools/tools.ts'
 
 const server = new Server(
   {
@@ -13,7 +13,7 @@ const server = new Server(
   },
   {
     capabilities: {
-      tools: toolDefinitions,
+      tools: toolDefinition,
     },
   },
 )


### PR DESCRIPTION
## Overview

This pull request adds a read-only mode feature to the Amazon CloudWatch Logs MCP server. When enabled, this mode restricts the server to only perform read operations, preventing any modifications to AWS resources.

### Changes

- Added a new `READONLY` environment variable to control read-only mode
- Categorized all tools as either READ or WRITE operations
- Implemented filtering logic to disable WRITE operations when read-only mode is enabled
- Updated documentation in README.md and TOOLS.md to explain the new feature
- Added operation type indicators to tool listings

### Benefits

- Provides a safer way to use the MCP server for monitoring and viewing logs without risk of accidental modifications
- Useful for scenarios where users need log access but should not have permission to modify log resources
- Improves security by allowing administrators to restrict capabilities based on user needs